### PR TITLE
fix: update volt.tml for lazy loading of plugins

### DIFF
--- a/volt.toml
+++ b/volt.toml
@@ -4,3 +4,7 @@ author = "panekj"
 display-name = "Go (gopls)"
 description = "Go for Lapce using gopls"
 wasm = "bin/lapce-go.wasm"
+
+[activation]
+language = ["go"]
+workspace-contains = ["*/go.mod"]


### PR DESCRIPTION
This is enough to fix plugin on latest nightly.

Signed-off-by: nheuillet <45401197+nheuillet@users.noreply.github.com>