### PR TITLE
Refactor to update to respond to initialization requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .DS_Store
 .AppleDouble
 .LSOverride
+justfile
 
 # Icon must end with two \r
 Icon

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-    "rust-analyzer.checkOnSave.command": "clippy",
-    "rust-analyzer.cargo.target": "wasm32-wasi",
-    "rust-analyzer.rustfmt.overrideCommand": ["cargo", "+nightly", "fmt"]
+  "rust-analyzer.checkOnSave.command": "clippy",
+  "rust-analyzer.cargo.target": "wasm32-wasi",
+  "rust-analyzer.rustfmt.overrideCommand": ["rustfmt", "+nightly"]
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,7 +94,7 @@ dependencies = [
 [[package]]
 name = "lapce-plugin"
 version = "0.1.0"
-source = "git+https://github.com/lapce/lapce-plugin-rust.git#8a2ad4bfba4d0fd1f80cdbdc772e8bfee624445f"
+source = "git+https://github.com/lapce/lapce-plugin-rust.git?rev=1657b855016c6bb50953e74eba4d079bf3173d63#1657b855016c6bb50953e74eba4d079bf3173d63"
 dependencies = [
  "anyhow",
  "bytes",
@@ -104,6 +104,7 @@ dependencies = [
  "psp-types",
  "serde",
  "serde_json",
+ "thiserror",
  "wasi-experimental-http",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,7 @@ serde = { version = "1.0", features = ["derive"] }
 [target.'cfg(target_os = "wasi")'.dependencies.volt]
 package = "lapce-plugin"
 git = "https://github.com/lapce/lapce-plugin-rust.git"
-# git = "https://github.com/panekj/lapce-plugin-rust.git"
-# branch = "volt"
-# path = "../../lapce-plugin-rust"
+rev = "1657b855016c6bb50953e74eba4d079bf3173d63"
 
 [profile.release]
 opt-level = 3


### PR DESCRIPTION
This PR assumes this other PR gets merged https://github.com/lapce/lapce-plugin-rust/pull/18

Also rename `initialize` => `calculate_lsp_params` and do effectful calls (like start_lsp and responding to request) in handle_request.

Signed-off-by: Hanif Bin Ariffin <hanif.ariffin.4326@gmail.com>