### PR TITLE
Support golang tools locally

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,1 @@
-nightly
+stable

--- a/volt.toml
+++ b/volt.toml
@@ -1,5 +1,5 @@
 name = "lapce-go"
-version = "2023.1.0"
+version = "2024.1.0"
 author = "panekj"
 display-name = "Go (gopls)"
 description = "Go for Lapce using gopls"


### PR DESCRIPTION
I found `lapce-go` have used old versions of go tools. So I just did a small update for using go tools from locally installed versions.